### PR TITLE
Fix whitelisted urls not being used

### DIFF
--- a/query.mjs
+++ b/query.mjs
@@ -49,7 +49,7 @@ const octokit = new Octokit({auth: process.env.GITHUB_TOKEN});
 
 let urls = urls_rsd;
 urls = urls.filter(includeWhitelisted);
-urls = await filterAsync(whitelist, includeHasCitationcff);
+urls = await filterAsync(urls, includeHasCitationcff);
 
 console.log(urls);
 


### PR DESCRIPTION
**Description**

Whitelisted `urls` from the previous filter (line 51) are being ignored in line 52.

**Related issues**:
- #27 

**Instructions to review the pull request**

- Make a GitHub Access token here https://github.com/settings/tokens
- export GITHUB_TOKEN
- install Node >= 14
- 
    
    ```
    cd $(mktemp -d --tmpdir cffbot-XXXXXX)
    git clone https://github.com/cffbots/filtering .
    git checkout <this-branch>
    npm install
    node query.mjs
    ```

<!--
Review online.
-->
