### PR TITLE
changed how the curated list of urls is printed

### DIFF
--- a/query.mjs
+++ b/query.mjs
@@ -110,8 +110,7 @@ urls = await filterAsync(urls, includeUsesPullRequests);
 urls = await filterAsync(urls, hasMultipleChangesToCitationcff);
 urls = await filterAsync(urls, includeUsesWorkflows);
 urls = await filterAsync(urls, hasRecentCommits);
-
-console.log(urls);
+urls.forEach(url => console.log(url))
 
 
 //const q = 'cffconvert-github-action in:file path:.github/workflows';


### PR DESCRIPTION
**Description**

This PR changes the way the final result is printed

**Related issues**:
- N/A

**Instructions to review the pull request**

- Make a GitHub Access token here https://github.com/settings/tokens
  - Make sure you copy it when it appears on screen, because you can't see it again. You can reset it, though.
- export GITHUB_TOKEN as an environment variable with the token above
- install Node >= 14
- &nbsp;
    ```
    cd $(mktemp -d --tmpdir cffbot-XXXXXX)
    git clone https://github.com/cffbots/filtering .
    git checkout <this-branch>
    npm install
    node query.mjs
    ```
