### PR TITLE
Filter by number of contributors with at least 5 contributions

### DIFF
--- a/query.mjs
+++ b/query.mjs
@@ -82,6 +82,25 @@ const hasRecentCommits = async (url) => {
     return elapsed <= inactivity_threshold
 }
 
+
+const hasSufficientContributors = async (url) => {
+    const [ owner, repo, ...unuseds ] = url.slice("https://github.com/".length).split('/');
+
+    const contributors = await octokit.rest.repos.listContributors({
+        owner,
+        repo,
+    });
+
+    let ncontributors = 0
+    for (const c of contributors.data) {
+        if (c.contributions >= ncontributions_minimum) {
+            ncontributors++;
+        }
+    }
+
+    return ncontributors >= ncontributors_minimum;
+}
+
 const filterAsync = async (arr, asyncCallback) => {
     const promises = arr.map(asyncCallback);
     const results = await Promise.all(promises);
@@ -101,6 +120,8 @@ const urls_rsd = loadFromJsonfile('./urls.json');
 const nworkflows_minimum = 1;
 const npull_requests_minimum = 5;
 const inactivity_threshold = 12 * 30 * 24 * 60 * 60 * 1000 // X months in milliseconds -> X months * 30 days/month * 24 hours/day * 60 min/hour * 60 sec/min * 1000
+const ncontributors_minimum = 3;
+const ncontributions_minimum = 5;
 
 const octokit = new Octokit({auth: process.env.GITHUB_TOKEN});
 
@@ -110,6 +131,7 @@ urls = await filterAsync(urls, includeUsesPullRequests);
 urls = await filterAsync(urls, hasMultipleChangesToCitationcff);
 urls = await filterAsync(urls, includeUsesWorkflows);
 urls = await filterAsync(urls, hasRecentCommits);
+urls = await filterAsync(urls, hasSufficientContributors);
 urls.forEach(url => console.log(url))
 
 


### PR DESCRIPTION
**Description**

Keep only repos that have at least 3 contributors with at least 5 contributions each.
At the current stage, there were 45 repos, and after this filter, there are 31.

**Related issues**:
- #36

**Instructions to review the pull request**

- Make a GitHub Access token here https://github.com/settings/tokens
  - Make sure you copy it when it appears on screen, because you can't see it again. You can reset it, though.
- export GITHUB_TOKEN as an environment variable with the token above
- install Node >= 14
-

    ```
    cd $(mktemp -d --tmpdir cffbot-XXXXXX)
    git clone https://github.com/cffbots/filtering .
    git checkout <this-branch>
    npm install
    node query.mjs
    ```
